### PR TITLE
Add options to refresh the credentials

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,13 +1,13 @@
 # User Guide
 
-- [Initializing a Client](#initializing-a-client)
-  - [To authenticate with the Amazon OpenSearch Service use AwsSigv4Signer](#to-authenticate-with-the-amazon-opensearch-service-use-awssigv4signer)
-- [Create an Index](#create-an-index)
-- [Add a Document to the Index](#add-a-document-to-the-index)
-- [Search for the Document](#search-for-the-document)
-- [Delete the document](#delete-the-document)
-- [Delete the index](#delete-the-index)
-
+- [User Guide](#user-guide)
+  - [Initializing a Client](#initializing-a-client)
+    - [To authenticate with Amazon OpenSearch Service using AwsSigv4Signer](#to-authenticate-with-amazon-opensearch-service-using-awssigv4signer)
+  - [Create an Index](#create-an-index)
+  - [Add a Document to the Index](#add-a-document-to-the-index)
+  - [Search for the Document](#search-for-the-document)
+  - [Delete the document](#delete-the-document)
+  - [Delete the index](#delete-the-index)
 
 ## Initializing a Client
 ```javascript
@@ -37,24 +37,26 @@ var client = new Client({
 });
 ```
 
-### To authenticate with the [Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) use AwsSigv4Signer
+### To authenticate with [Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) using AwsSigv4Signer
 
 ```javascript
-const endpoint = ""; // OpenSearch domain URL e.g. https://search-xxx.region.es.amazonaws.com
+const { defaultProvider } = require("@aws-sdk/credential-provider-node");
 const { Client } = require('@opensearch-project/opensearch');
 const { AwsSigv4Signer } = require('@opensearch-project/opensearch/aws');
-const { defaultProvider } = require("@aws-sdk/credential-provider-node");
 
 async function getClient() {
-  const credentials = await defaultProvider()();
-  var client = new Client({
-    ...AwsSigv4Signer({
-      credentials: credentials,
-      region: "us-west-2",
-    }),
+  const connection = await AwsSigv4Signer({
+    getCredentials: async () => {
+      const credentials = await defaultProvider()();
+      return credentials;
+    },
+    refresh: false, // Enable refreshing credentials.
+    refreshInterval: 1000 * 1000 * 60 * 14, // default to 14 minutes, must be set to a value below the expiration time of the credentials.
+  });
+  return new Client({
+    ...connection,
     node: endpoint,
   });
-  return client;
 }
 ```
 
@@ -80,7 +82,7 @@ async function getClient() {
   console.log(response.body);
 ```
 
-## Add a Document to the Index 
+## Add a Document to the Index
 
 ```javascript
   var document = {

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -48,7 +48,10 @@ const endpoint = ""; // OpenSearch domain URL e.g. https://search-xxx.region.es.
 
 async function getClient() {
   const connection = await AwsSigv4Signer({
-    // Must return an AWS.Credential object.
+    region: 'us-east-1',
+    // Must return an AWS.Credentials object.
+    // This function is used when initializing the client and
+    // when the credentials are expired.
     // Example with aws sdk V3:
     getCredentials: async () => {
       const credentials = await defaultProvider()();
@@ -69,8 +72,6 @@ async function getClient() {
           }
         });
       }),
-    refresh: true, // Optional, enable refreshing credentials, disabled by default.
-    refreshInterval: 1000 * 60 * 14, // optional, default to 14 minutes, must be set to a value below the expiration time of the credentials.
   });
   return new Client({
     ...connection,

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -11,15 +11,13 @@
 
 'use strict';
 const Connection = require('../Connection');
+const Transport = require('../Transport');
 const aws4 = require('aws4');
 const AwsSigv4SignerError = require('./errors');
-
-const DEFAULT_REFRESH_INTERVAL = 1000 * 60 * 14; // 14 minutes.
 
 async function AwsSigv4Signer(opts) {
   const credentialsState = {
     credentials: null,
-    refreshInterval: null,
   };
   if (opts && (!opts.region || opts.region === null || opts.region === '')) {
     throw new AwsSigv4SignerError('Region cannot be empty');
@@ -32,21 +30,6 @@ async function AwsSigv4Signer(opts) {
     credentialsState.credentials = await opts.getCredentials();
   } catch (error) {
     throw new AwsSigv4SignerError('fetching credentials failed', error);
-  }
-
-  if (opts && opts.refresh === true && !credentialsState.refreshInterval) {
-    credentialsState.refreshInterval = setInterval(
-      async () => {
-        try {
-          credentialsState.credentials = await opts.getCredentials();
-        } catch (error) {
-          throw new AwsSigv4SignerError('fetching credentials failed', error);
-        }
-      },
-      typeof opts.refreshInterval === 'number'
-        ? Math.max(opts.refreshInterval, DEFAULT_REFRESH_INTERVAL)
-        : DEFAULT_REFRESH_INTERVAL
-    );
   }
 
   function buildSignedRequestObject(request = {}) {
@@ -63,9 +46,55 @@ async function AwsSigv4Signer(opts) {
     }
   }
 
+  class AwsSigv4SignerTransport extends Transport {
+    request(params, options = {}, callback = undefined) {
+      // options is optional,
+      // so if it is omitted, options will be the callback
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+
+      /** @type {import('aws-sdk').Credentials} */
+      const currentCredentials = credentialsState.credentials;
+
+      const expired =
+        (typeof currentCredentials.expired !== 'undefined' && currentCredentials.expired) ||
+        (typeof currentCredentials.expiration !== 'undefined' &&
+          currentCredentials.expiration < new Date()) ||
+        (typeof currentCredentials.expired === 'undefined' &&
+          typeof currentCredentials.expiration === 'undefined');
+
+      if (expired) {
+        // Promise support
+        if (typeof callback === 'undefined') {
+          return opts.getCredentials().then((newCredentials) => {
+            credentialsState.credentials = newCredentials;
+            return super.request(params, options);
+          });
+        }
+
+        // Callback support
+        opts
+          .getCredentials()
+          .then((newCredentials) => {
+            credentialsState.credentials = newCredentials;
+            return super.request(params, options, callback);
+          })
+          .catch(callback);
+      } else if (typeof callback === 'undefined') {
+        return super.request(params, options);
+      } else {
+        super.request(params, options, callback);
+      }
+    }
+  }
+
   return {
+    Transport: AwsSigv4SignerTransport,
     Connection: AwsSigv4SignerConnection,
     buildSignedRequestObject,
+    credentialsState,
   };
 }
 module.exports = AwsSigv4Signer;

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -14,12 +14,42 @@ const Connection = require('../Connection');
 const aws4 = require('aws4');
 const AwsSigv4SignerError = require('./errors');
 
-function AwsSigv4Signer(opts) {
+const DEFAULT_REFRESH_INTERVAL = 1000 * 60 * 14; // 14 minutes.
+
+/**
+ * @returns {Promise<Connection>}
+ */
+async function AwsSigv4Signer(opts) {
+  const credentialsState = {
+    credentials: null,
+    refreshInterval: null,
+  };
   if (opts && (!opts.region || opts.region === null || opts.region === '')) {
     throw new AwsSigv4SignerError('Region cannot be empty');
   }
-  if (opts && (!opts.credentials || opts.credentials === null || opts.credentials === '')) {
-    throw new AwsSigv4SignerError('Credentials cannot be empty');
+  if (opts && typeof opts.getCredentials !== 'function') {
+    throw new AwsSigv4SignerError('getCredentials function is required');
+  }
+
+  try {
+    credentialsState.credentials = await opts.getCredentials();
+  } catch (error) {
+    throw new AwsSigv4SignerError('fetching credentials failed', error);
+  }
+
+  if (opts && opts.refresh === true && !credentialsState.refreshInterval) {
+    credentialsState.refreshInterval = setInterval(
+      async () => {
+        try {
+          credentialsState.credentials = await opts.getCredentials();
+        } catch (error) {
+          throw new AwsSigv4SignerError('fetching credentials failed', error);
+        }
+      },
+      typeof opts.refreshInterval === 'number'
+        ? Math.max(opts.refreshInterval, DEFAULT_REFRESH_INTERVAL)
+        : DEFAULT_REFRESH_INTERVAL
+    );
   }
 
   function buildSignedRequestObject(request = {}) {
@@ -27,7 +57,7 @@ function AwsSigv4Signer(opts) {
     request.region = opts.region;
     request.headers = request.headers || {};
     request.headers['host'] = request.hostname;
-    return aws4.sign(request, opts.credentials);
+    return aws4.sign(request, credentialsState.credentials);
   }
   class AwsSigv4SignerConnection extends Connection {
     buildRequestObject(params) {
@@ -35,6 +65,7 @@ function AwsSigv4Signer(opts) {
       return buildSignedRequestObject(request);
     }
   }
+
   return {
     Connection: AwsSigv4SignerConnection,
     buildSignedRequestObject,

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -16,9 +16,6 @@ const AwsSigv4SignerError = require('./errors');
 
 const DEFAULT_REFRESH_INTERVAL = 1000 * 60 * 14; // 14 minutes.
 
-/**
- * @returns {Promise<Connection>}
- */
 async function AwsSigv4Signer(opts) {
   const credentialsState = {
     credentials: null,

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -13,22 +13,22 @@
 
 import { Credentials } from '@aws-sdk/types';
 import Connection from '../Connection';
+import Transport from '../Transport';
 import * as http from 'http';
 import { OpenSearchClientError } from '../errors';
 
 interface AwsSigv4SignerOptions {
   getCredentials: () => Promise<Credentials>;
   region: string;
-  refresh?: boolean;
-  refreshInterval?: number;
 }
 
 interface AwsSigv4SignerResponse {
   Connection: Connection;
+  Transport: Transport,
   buildSignedRequestObject(request: any): http.ClientRequestArgs;
 }
 
-type AwsSigv4Signer = (opts: AwsSigv4SignerOptions) => Promise<AwsSigv4SignerResponse>;
+declare function AwsSigv4Signer (opts: AwsSigv4SignerOptions): Promise<AwsSigv4SignerResponse>;
 
 declare class AwsSigv4SignerError extends OpenSearchClientError {
   name: string;

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -17,8 +17,10 @@ import * as http from 'http';
 import { OpenSearchClientError } from '../errors';
 
 interface AwsSigv4SignerOptions {
-  credentials: Credentials;
+  getCredentials: () => Promise<Credentials>;
   region: string;
+  refresh?: boolean;
+  refreshInterval?: number;
 }
 
 interface AwsSigv4SignerResponse {
@@ -26,7 +28,7 @@ interface AwsSigv4SignerResponse {
   buildSignedRequestObject(request: any): http.ClientRequestArgs;
 }
 
-declare function AwsSigv4Signer(opts: AwsSigv4SignerOptions): AwsSigv4SignerResponse;
+declare function AwsSigv4Signer(opts: AwsSigv4SignerOptions): Promise<AwsSigv4SignerResponse>;
 
 declare class AwsSigv4SignerError extends OpenSearchClientError {
   name: string;

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -28,7 +28,7 @@ interface AwsSigv4SignerResponse {
   buildSignedRequestObject(request: any): http.ClientRequestArgs;
 }
 
-declare function AwsSigv4Signer(opts: AwsSigv4SignerOptions): Promise<AwsSigv4SignerResponse>;
+type AwsSigv4Signer = (opts: AwsSigv4SignerOptions) => Promise<AwsSigv4SignerResponse>;
 
 declare class AwsSigv4SignerError extends OpenSearchClientError {
   name: string;

--- a/test/types/awssigv4signer.test-d.ts
+++ b/test/types/awssigv4signer.test-d.ts
@@ -8,24 +8,24 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-
-import { Credentials } from '@aws-sdk/types';
 import { expectType } from 'tsd';
 const { v4: uuidv4 } = require('uuid');
 import { AwsSigv4SignerResponse, AwsSigv4Signer } from '../../lib/aws';
 
-const mockCreds: Credentials = {
+const mockCreds = {
   accessKeyId: uuidv4(),
   secretAccessKey: uuidv4(),
+  expired: false,
+  expiration: new Date(),
+  sessionToken: uuidv4(),
 };
 
-const mockRegion = 'us-west-2';
+const mockRegion = 'us-east-1';
 
 {
   const AwsSigv4SignerOptions = {
     getCredentials: () => Promise.resolve(mockCreds),
     region: mockRegion,
-    refresh: true,
   };
 
   const auth = AwsSigv4Signer(AwsSigv4SignerOptions);

--- a/test/types/awssigv4signer.test-d.ts
+++ b/test/types/awssigv4signer.test-d.ts
@@ -9,11 +9,12 @@
  * GitHub history for details.
  */
 
+import { Credentials } from '@aws-sdk/types';
 import { expectType } from 'tsd';
 const { v4: uuidv4 } = require('uuid');
 import { AwsSigv4SignerResponse, AwsSigv4Signer } from '../../lib/aws';
 
-const mockCreds = {
+const mockCreds: Credentials = {
   accessKeyId: uuidv4(),
   secretAccessKey: uuidv4(),
 };
@@ -21,9 +22,13 @@ const mockCreds = {
 const mockRegion = 'us-west-2';
 
 {
-  const AwsSigv4SignerOptions = { credentials: mockCreds, region: mockRegion };
+  const AwsSigv4SignerOptions = {
+    getCredentials: () => Promise.resolve(mockCreds),
+    region: mockRegion,
+    refresh: true,
+  };
 
   const auth = AwsSigv4Signer(AwsSigv4SignerOptions);
 
-  expectType<AwsSigv4SignerResponse>(auth);
+  expectType<Promise<AwsSigv4SignerResponse>>(auth);
 }


### PR DESCRIPTION
tldr;
- replace static credentials option for a promise that return new credentials
- option to refresh the credentials periodically

todo:
- [x] add tests (need to figure what tests we need)

usage:

```javascript
const AWS = require('aws-sdk');
const { Client } = require('@opensearch-project/opensearch');
const { AwsSigv4Signer } = require('@opensearch-project/opensearch/aws');

async function getClient() {
  const connection = await AwsSigv4Signer({
    region: 'us-east-1',
    getCredentials: () =>
      new Promise((resolve, reject) => {
        AWS.config.getCredentials((err, credentials) => {
          if (err) {
            reject(err);
          } else {
            resolve(credentials);
          }
        });
      }),
    refresh: true,
    refreshInterval: 1000 * 60 * 60 * 14,
  });
  config.client = new Client({
    ...connection,
    node: 'https://endpoint.host',
  });
}
```