### PR TITLE
update credentials refresh and expiration

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -51,15 +51,20 @@ const client = new Client({
     // Must return a Promise that resolve to an AWS.Credentials object.
     // This function is used to acquire the credentials when the client start and
     // when the credentials are expired.
-    // Credentials.refreshPromise is used instead to refresh the credentials
-    // when availabe (aws sdk v2)
+    // The Client will refresh the Credentials only when they are expired.
+    // With AWS SDK V2, Credentials.refreshPromise is used when available to refresh the credentials.
 
-    // Example with aws sdk V3:
-    getCredentials: defaultProvider(),
+    // Example with AWS SDK V3:
+    getCredentials: async () => {
+      // Any other method to acquire a new Credentials object can be used.
+      const credentialsProvider = defaultProvider();
+      return credentialsProvider();
+    },
 
-    // Or with v2 for example:
+    // Example with AWS SDK V2:
     getCredentials: () =>
       new Promise((resolve, reject) => {
+        // Any other method to acquire a new Credentials object can be used.
         AWS.config.getCredentials((err, credentials) => {
           if (err) {
             reject(err);
@@ -69,7 +74,7 @@ const client = new Client({
         });
       }),
   }),
-  node: "", // OpenSearch domain URL e.g. https://search-xxx.region.es.amazonaws.com
+  node: "https://search-xxx.region.es.amazonaws.com", // OpenSearch domain URL
 });
 
 ```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -55,7 +55,7 @@ const client = new Client({
     // With AWS SDK V2, Credentials.refreshPromise is used when available to refresh the credentials.
 
     // Example with AWS SDK V3:
-    getCredentials: async () => {
+    getCredentials: () => {
       // Any other method to acquire a new Credentials object can be used.
       const credentialsProvider = defaultProvider();
       return credentialsProvider();

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -44,26 +44,32 @@ function AwsSigv4Signer(opts) {
 
   class AwsSigv4SignerTransport extends Transport {
     request(params, options = {}, callback = undefined) {
-      // options is optional,
-      // so if it is omitted, options will be the callback
+      // options is optional so if options is a function, it's the callback.
       if (typeof options === 'function') {
-        // eslint-disable-next-line no-param-reassign
         callback = options;
-        // eslint-disable-next-line no-param-reassign
         options = {};
       }
 
       const currentCredentials = credentialsState.credentials;
       let expired = false;
       if (!currentCredentials) {
+        // Credentials haven't been acquired yet.
         expired = true;
-      } else if (typeof currentCredentials.needsRefresh === 'function') {
+      }
+      // AWS SDK V2, needsRefresh should be available.
+      else if (typeof currentCredentials.needsRefresh === 'function') {
         expired = currentCredentials.needsRefresh();
-      } else if (currentCredentials.expired === true) {
+      }
+      // AWS SDK V2, alternative to needsRefresh.
+      else if (currentCredentials.expired === true) {
         expired = true;
-      } else if (currentCredentials.expireTime && currentCredentials.expireTime < new Date()) {
+      }
+      // AWS SDK V2, alternative to needsRefresh and expired.
+      else if (currentCredentials.expireTime && currentCredentials.expireTime < new Date()) {
         expired = true;
-      } else if (currentCredentials.expiration && currentCredentials.expiration < new Date()) {
+      }
+      // AWS SDK V3, Credentials.expiration is a Date object
+      else if (currentCredentials.expiration && currentCredentials.expiration < new Date()) {
         expired = true;
       }
 
@@ -71,11 +77,11 @@ function AwsSigv4Signer(opts) {
         if (typeof callback === 'undefined') {
           return super.request(params, options);
         }
-
         super.request(params, options, callback);
         return;
       }
 
+      // In AWS SDK V2 Credentials.refreshPromise should be available.
       if (currentCredentials && typeof currentCredentials.refreshPromise === 'function') {
         if (typeof callback === 'undefined') {
           return currentCredentials.refreshPromise().then(() => {
@@ -94,6 +100,7 @@ function AwsSigv4Signer(opts) {
         }
       }
 
+      // For AWS SDK V3 or when the client has not acquired credentials yet.
       if (typeof callback === 'undefined') {
         return opts.getCredentials().then((credentials) => {
           credentialsState.acquiredAt = Date.now();

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -18,7 +18,6 @@ const AwsSigv4SignerError = require('./errors');
 function AwsSigv4Signer(opts) {
   const credentialsState = {
     credentials: null,
-    acquiredAt: 0,
   };
   if (opts && (!opts.region || opts.region === null || opts.region === '')) {
     throw new AwsSigv4SignerError('Region cannot be empty');
@@ -85,14 +84,12 @@ function AwsSigv4Signer(opts) {
       if (currentCredentials && typeof currentCredentials.refreshPromise === 'function') {
         if (typeof callback === 'undefined') {
           return currentCredentials.refreshPromise().then(() => {
-            credentialsState.acquiredAt = Date.now();
             return super.request(params, options);
           });
         } else {
           currentCredentials
             .refreshPromise()
             .then(() => {
-              credentialsState.acquiredAt = Date.now();
               super.request(params, options, callback);
             })
             .catch(callback);
@@ -103,7 +100,6 @@ function AwsSigv4Signer(opts) {
       // For AWS SDK V3 or when the client has not acquired credentials yet.
       if (typeof callback === 'undefined') {
         return opts.getCredentials().then((credentials) => {
-          credentialsState.acquiredAt = Date.now();
           credentialsState.credentials = credentials;
           return super.request(params, options);
         });
@@ -111,7 +107,6 @@ function AwsSigv4Signer(opts) {
         opts
           .getCredentials()
           .then((credentials) => {
-            credentialsState.acquiredAt = Date.now();
             credentialsState.credentials = credentials;
             super.request(params, options, callback);
           })

--- a/lib/aws/AwsSigv4Signer.js
+++ b/lib/aws/AwsSigv4Signer.js
@@ -15,21 +15,16 @@ const Transport = require('../Transport');
 const aws4 = require('aws4');
 const AwsSigv4SignerError = require('./errors');
 
-async function AwsSigv4Signer(opts) {
+function AwsSigv4Signer(opts) {
   const credentialsState = {
     credentials: null,
+    acquiredAt: 0,
   };
   if (opts && (!opts.region || opts.region === null || opts.region === '')) {
     throw new AwsSigv4SignerError('Region cannot be empty');
   }
   if (opts && typeof opts.getCredentials !== 'function') {
     throw new AwsSigv4SignerError('getCredentials function is required');
-  }
-
-  try {
-    credentialsState.credentials = await opts.getCredentials();
-  } catch (error) {
-    throw new AwsSigv4SignerError('fetching credentials failed', error);
   }
 
   function buildSignedRequestObject(request = {}) {
@@ -39,6 +34,7 @@ async function AwsSigv4Signer(opts) {
     request.headers['host'] = request.hostname;
     return aws4.sign(request, credentialsState.credentials);
   }
+
   class AwsSigv4SignerConnection extends Connection {
     buildRequestObject(params) {
       const request = super.buildRequestObject(params);
@@ -51,41 +47,68 @@ async function AwsSigv4Signer(opts) {
       // options is optional,
       // so if it is omitted, options will be the callback
       if (typeof options === 'function') {
+        // eslint-disable-next-line no-param-reassign
         callback = options;
+        // eslint-disable-next-line no-param-reassign
         options = {};
       }
 
-      /** @type {import('aws-sdk').Credentials} */
       const currentCredentials = credentialsState.credentials;
+      let expired = false;
+      if (!currentCredentials) {
+        expired = true;
+      } else if (typeof currentCredentials.needsRefresh === 'function') {
+        expired = currentCredentials.needsRefresh();
+      } else if (currentCredentials.expired === true) {
+        expired = true;
+      } else if (currentCredentials.expireTime && currentCredentials.expireTime < new Date()) {
+        expired = true;
+      } else if (currentCredentials.expiration && currentCredentials.expiration < new Date()) {
+        expired = true;
+      }
 
-      const expired =
-        (typeof currentCredentials.expired !== 'undefined' && currentCredentials.expired) ||
-        (typeof currentCredentials.expiration !== 'undefined' &&
-          currentCredentials.expiration < new Date()) ||
-        (typeof currentCredentials.expired === 'undefined' &&
-          typeof currentCredentials.expiration === 'undefined');
-
-      if (expired) {
-        // Promise support
+      if (!expired) {
         if (typeof callback === 'undefined') {
-          return opts.getCredentials().then((newCredentials) => {
-            credentialsState.credentials = newCredentials;
-            return super.request(params, options);
-          });
+          return super.request(params, options);
         }
 
-        // Callback support
+        super.request(params, options, callback);
+        return;
+      }
+
+      if (currentCredentials && typeof currentCredentials.refreshPromise === 'function') {
+        if (typeof callback === 'undefined') {
+          return currentCredentials.refreshPromise().then(() => {
+            credentialsState.acquiredAt = Date.now();
+            return super.request(params, options);
+          });
+        } else {
+          currentCredentials
+            .refreshPromise()
+            .then(() => {
+              credentialsState.acquiredAt = Date.now();
+              super.request(params, options, callback);
+            })
+            .catch(callback);
+          return;
+        }
+      }
+
+      if (typeof callback === 'undefined') {
+        return opts.getCredentials().then((credentials) => {
+          credentialsState.acquiredAt = Date.now();
+          credentialsState.credentials = credentials;
+          return super.request(params, options);
+        });
+      } else {
         opts
           .getCredentials()
-          .then((newCredentials) => {
-            credentialsState.credentials = newCredentials;
-            return super.request(params, options, callback);
+          .then((credentials) => {
+            credentialsState.acquiredAt = Date.now();
+            credentialsState.credentials = credentials;
+            super.request(params, options, callback);
           })
           .catch(callback);
-      } else if (typeof callback === 'undefined') {
-        return super.request(params, options);
-      } else {
-        super.request(params, options, callback);
       }
     }
   }
@@ -94,7 +117,6 @@ async function AwsSigv4Signer(opts) {
     Transport: AwsSigv4SignerTransport,
     Connection: AwsSigv4SignerConnection,
     buildSignedRequestObject,
-    credentialsState,
   };
 }
 module.exports = AwsSigv4Signer;

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -23,8 +23,8 @@ interface AwsSigv4SignerOptions {
 }
 
 interface AwsSigv4SignerResponse {
-  Connection: Connection;
-  Transport: Transport;
+  Connection: typeof Connection;
+  Transport: typeof Transport;
   buildSignedRequestObject(request: any): http.ClientRequestArgs;
 }
 

--- a/lib/aws/index.d.ts
+++ b/lib/aws/index.d.ts
@@ -24,11 +24,11 @@ interface AwsSigv4SignerOptions {
 
 interface AwsSigv4SignerResponse {
   Connection: Connection;
-  Transport: Transport,
+  Transport: Transport;
   buildSignedRequestObject(request: any): http.ClientRequestArgs;
 }
 
-declare function AwsSigv4Signer (opts: AwsSigv4SignerOptions): Promise<AwsSigv4SignerResponse>;
+declare function AwsSigv4Signer (opts: AwsSigv4SignerOptions): AwsSigv4SignerResponse;
 
 declare class AwsSigv4SignerError extends OpenSearchClientError {
   name: string;

--- a/test/types/awssigv4signer.test-d.ts
+++ b/test/types/awssigv4signer.test-d.ts
@@ -16,7 +16,7 @@ const mockCreds = {
   accessKeyId: uuidv4(),
   secretAccessKey: uuidv4(),
   expired: false,
-  expiration: new Date(),
+  expireTime: new Date(),
   sessionToken: uuidv4(),
 };
 
@@ -30,5 +30,5 @@ const mockRegion = 'us-east-1';
 
   const auth = AwsSigv4Signer(AwsSigv4SignerOptions);
 
-  expectType<Promise<AwsSigv4SignerResponse>>(auth);
+  expectType<AwsSigv4SignerResponse>(auth);
 }


### PR DESCRIPTION
- handle properly expiration check for sdk v3
- uses Credentials method to refresh and check the credentials expiration when available (v2)
- make AwsSigv4Signer synchronous
- add tests to check credentials refresh / expiration handlers

@harshavamsi 
> @rawpixel-vincent I'm relatively new to the code base, but jumping through the stack trace for each transport request. I do see that the [request method](https://github.com/harshavamsi/opensearch-js/blob/main/lib/Transport.js#L114) calls the connections [meta request](https://github.com/harshavamsi/opensearch-js/blob/main/lib/Transport.js#L211) method. So the request is being built every time an API call is made, i.e. the credentials can be checked and refreshed at the connection level instead of overriding the transport layer.

> I'm not saying that we should change this implementation, because it would be identical if we implemented this at the Connection layer or the Transport layer. But just leaving this here as something I learnt.

I did made an attempt to override Connection.request (instead of Transport.request), but `Connection.buildRequestObject()` method is called before `Connection.request()` so with that flow, the credentials won't be renewed (if they need to be) before the request is signed.

I've again launched this PR in a staging environment to test this implementation with temporary credentials using the v2 SDK.